### PR TITLE
Add `consoles` and `terminals` handlers for RetroLab

### DIFF
--- a/plugins/retrolab/fps_retrolab/routes.py
+++ b/plugins/retrolab/fps_retrolab/routes.py
@@ -50,7 +50,7 @@ async def get_notebook(
     name: str,
     user: User = Depends(current_user()),
 ):
-    return get_index(name, "notebook")
+    return get_index(name, "notebooks")
 
 
 @router.get("/retro/consoles/{name}", response_class=HTMLResponse)

--- a/plugins/retrolab/fps_retrolab/routes.py
+++ b/plugins/retrolab/fps_retrolab/routes.py
@@ -53,6 +53,22 @@ async def get_notebook(
     return get_index(name, "notebook")
 
 
+@router.get("/retro/consoles/{name}", response_class=HTMLResponse)
+async def get_console(
+    name: str,
+    user: User = Depends(current_user()),
+):
+    return get_index(name, "consoles")
+
+
+@router.get("/retro/terminals/{name}", response_class=HTMLResponse)
+async def get_terminal(
+    name: str,
+    user: User = Depends(current_user()),
+):
+    return get_index(name, "terminals")
+
+
 @router.get("/lab/api/settings/@jupyterlab/{name0}:{name1}")
 async def get_setting(
     name0,


### PR DESCRIPTION
Consoles and terminals are also supported in RetroLab.