### PR TITLE
Automated Changelog Entry for 0.0.8 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
-## 0.0.7
+## 0.0.8
+
+([Full Changelog](https://github.com/jupyter-server/jupyverse/compare/0.0.7...8003fb634d36fcb9dd6bc21f861a3feb2620891a))
+
+### Maintenance and upkeep improvements
+
+- Prepare for use with Jupyter Releaser [#81](https://github.com/jupyter-server/jupyverse/pull/81) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Other merged PRs
+
+- Support editing file [#84](https://github.com/jupyter-server/jupyverse/pull/84) ([@davidbrochart](https://github.com/davidbrochart))
+- Filter out messages [#83](https://github.com/jupyter-server/jupyverse/pull/83) ([@davidbrochart](https://github.com/davidbrochart))
+- Change license from MIT to BSD-3-Clause [#82](https://github.com/jupyter-server/jupyverse/pull/82) ([@davidbrochart](https://github.com/davidbrochart))
+- Allow KernelServer to connect to existing kernel [#80](https://github.com/jupyter-server/jupyverse/pull/80) ([@davidbrochart](https://github.com/davidbrochart))
+- Fix Binder [#79](https://github.com/jupyter-server/jupyverse/pull/79) ([@davidbrochart](https://github.com/davidbrochart))
+- Create lab plugin, common to jupyterlab and retrolab [#78](https://github.com/jupyter-server/jupyverse/pull/78) ([@davidbrochart](https://github.com/davidbrochart))
+- Improve Binder and launch jupyverse directly [#76](https://github.com/jupyter-server/jupyverse/pull/76) ([@davidbrochart](https://github.com/davidbrochart))
+- Support RetroLab in Binder [#72](https://github.com/jupyter-server/jupyverse/pull/72) ([@davidbrochart](https://github.com/davidbrochart))
+- Improve retrolab [#69](https://github.com/jupyter-server/jupyverse/pull/69) ([@davidbrochart](https://github.com/davidbrochart))
+- Redirect to login page when not authorized [#68](https://github.com/jupyter-server/jupyverse/pull/68) ([@davidbrochart](https://github.com/davidbrochart))
+- Use `fps_uvicorn` plugin [#67](https://github.com/jupyter-server/jupyverse/pull/67) ([@adriendelsalle](https://github.com/adriendelsalle))
+- Add persistence settings test [#66](https://github.com/jupyter-server/jupyverse/pull/66) ([@davidbrochart](https://github.com/davidbrochart))
+- Add settings test [#65](https://github.com/jupyter-server/jupyverse/pull/65) ([@davidbrochart](https://github.com/davidbrochart))
+- Fix OpenAPI generation for NoAuthAuthentication [#64](https://github.com/jupyter-server/jupyverse/pull/64) ([@davidbrochart](https://github.com/davidbrochart))
+- Rework noauth [#62](https://github.com/jupyter-server/jupyverse/pull/62) ([@davidbrochart](https://github.com/davidbrochart))
+- Use get_user_db dependency [#60](https://github.com/jupyter-server/jupyverse/pull/60) ([@davidbrochart](https://github.com/davidbrochart))
+- Remove unneeded dependencies [#59](https://github.com/jupyter-server/jupyverse/pull/59) ([@davidbrochart](https://github.com/davidbrochart))
+- Use FastAPI-Users 8.0 [#58](https://github.com/jupyter-server/jupyverse/pull/58) ([@davidbrochart](https://github.com/davidbrochart))
+- Fix some full URLs [#57](https://github.com/jupyter-server/jupyverse/pull/57) ([@davidbrochart](https://github.com/davidbrochart))
+- Implement jlab translations API [#56](https://github.com/jupyter-server/jupyverse/pull/56) ([@davidbrochart](https://github.com/davidbrochart))
+- Add `consoles` and `terminals` handlers for RetroLab [#54](https://github.com/jupyter-server/jupyverse/pull/54) ([@jtpio](https://github.com/jtpio))
+- Replace references to adriendelsalle with jupyter-server [#52](https://github.com/jupyter-server/jupyverse/pull/52) ([@davidbrochart](https://github.com/davidbrochart))
+- Replace references to davidbrochart by jupyter-server [#51](https://github.com/jupyter-server/jupyverse/pull/51) ([@davidbrochart](https://github.com/davidbrochart))
+- Make clarification clearer re: experimental [#50](https://github.com/jupyter-server/jupyverse/pull/50) ([@willingc](https://github.com/willingc))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyverse/graphs/contributors?from=2021-09-16&to=2021-10-11&type=c))
+
+[@adriendelsalle](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyverse+involves%3Aadriendelsalle+updated%3A2021-09-16..2021-10-11&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyverse+involves%3Adavidbrochart+updated%3A2021-09-16..2021-10-11&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyverse+involves%3Afcollonval+updated%3A2021-09-16..2021-10-11&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyverse+involves%3Ahbcarlos+updated%3A2021-09-16..2021-10-11&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyverse+involves%3Ajtpio+updated%3A2021-09-16..2021-10-11&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyverse+involves%3Awelcome+updated%3A2021-09-16..2021-10-11&type=Issues) | [@willingc](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyverse+involves%3Awillingc+updated%3A2021-09-16..2021-10-11&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
+
+## 0.0.7


### PR DESCRIPTION
Automated Changelog Entry for 0.0.8 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/jupyverse  |
| Branch  | main  |
| Version Spec | 0.0.8 |
| Since | 0.0.7 |