### PR TITLE
Automated Changelog Entry for 0.0.13 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.0.13
+
+([Full Changelog](https://github.com/jupyter-server/jupyverse/compare/v0.0.12...8561f58f9d75d7e822646a5ac2f47af6f75befcb))
+
+### Merged PRs
+
+- Add aiosqlite to fps-auth dependencies [#95](https://github.com/jupyter-server/jupyverse/pull/95) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyverse/graphs/contributors?from=2021-10-11&to=2021-10-11&type=c))
+
+[@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyverse+involves%3Adavidbrochart+updated%3A2021-10-11..2021-10-11&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.0.12
 
 ([Full Changelog](https://github.com/jupyter-server/jupyverse/compare/v0.0.11...c109da7a6a9b9801cfecc971893823c213d995aa))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyverse/graphs/contributors?from=2021-10-11&to=2021-10-11&type=c))
 
 [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyverse+involves%3Adavidbrochart+updated%3A2021-10-11..2021-10-11&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.0.11
 


### PR DESCRIPTION
Automated Changelog Entry for 0.0.13 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/jupyverse  |
| Branch  | main  |
| Version Spec | 0.0.13 |
| Since | v0.0.12 |