### PR TITLE
Automated Changelog Entry for 0.0.23 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,26 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.0.23
+
+([Full Changelog](https://github.com/jupyter-server/jupyverse/compare/v0.0.22...fa401365d5e322fa6c41c66648553c820d830289))
+
+### Merged PRs
+
+- Update Python packages with new Jupyter Releaser [#119](https://github.com/jupyter-server/jupyverse/pull/119) ([@davidbrochart](https://github.com/davidbrochart))
+- Update Python packages with new Jupyter Releaser [#118](https://github.com/jupyter-server/jupyverse/pull/118) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyverse/graphs/contributors?from=2021-11-05&to=2021-11-05&type=c))
+
+[@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyverse+involves%3Adavidbrochart+updated%3A2021-11-05..2021-11-05&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.0.22
 
 No merged PRs
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.0.21
 


### PR DESCRIPTION
Automated Changelog Entry for 0.0.23 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/jupyverse  |
| Branch  | main  |
| Version Spec | 0.0.23 |
| Since | v0.0.22 |