### PR TITLE
Don't install fps-terminals on Windows

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
   fps-auth
   fps-contents
   fps-kernels
-  fps-terminals
+  fps-terminals;platform_system!='Windows'
   fps-nbconvert
   fps-yjs
 


### PR DESCRIPTION
Not installing the `fps-terminals` plugin on Windows at least makes it possible to run jupyverse, even though terminals won't work on this platform.
Will need to be reverted when we have a solution for #102.