### PR TITLE
Automated Changelog Entry for 0.0.32 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.0.32
+
+([Full Changelog](https://github.com/jupyter-server/jupyverse/compare/v0.0.31...7cef3ccb7073e67734270e7b05e2645ace959aff))
+
+### Merged PRs
+
+- Include explicit package data [#173](https://github.com/jupyter-server/jupyverse/pull/173) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyverse/graphs/contributors?from=2022-03-25&to=2022-03-25&type=c))
+
+[@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyverse+involves%3Adavidbrochart+updated%3A2022-03-25..2022-03-25&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.0.31
 
 ([Full Changelog](https://github.com/jupyter-server/jupyverse/compare/v0.0.30...5e050741eb9bf0b36f058065edd84791f2e0a11a))
@@ -16,8 +32,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyverse/graphs/contributors?from=2022-03-22&to=2022-03-25&type=c))
 
 [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyverse+involves%3Adavidbrochart+updated%3A2022-03-22..2022-03-25&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.0.30
 


### PR DESCRIPTION
Automated Changelog Entry for 0.0.32 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/jupyverse  |
| Branch  | main  |
| Version Spec | 0.0.32 |
| Since | v0.0.31 |