### PR TITLE
fix zmq Socket types

### DIFF
--- a/plugins/kernels/fps_kernels/kernel_server/connect.py
+++ b/plugins/kernels/fps_kernels/kernel_server/connect.py
@@ -9,7 +9,7 @@ from typing import Dict, Optional, Tuple, Union
 import zmq
 import zmq.asyncio
 from fastapi import WebSocket
-from zmq.sugar.socket import Socket
+from zmq.asyncio import Socket
 
 channel_socket_types = {
     "hb": zmq.REQ,

--- a/plugins/kernels/fps_kernels/kernel_server/message.py
+++ b/plugins/kernels/fps_kernels/kernel_server/message.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple, cast
 from uuid import uuid4
 
-from zmq.sugar.socket import Socket
+from zmq.asyncio import Socket
 from zmq.utils import jsonapi
 
 protocol_version_info = (5, 3)


### PR DESCRIPTION
jupyverse assumes zmq.asyncio.Socket, not the base blocking class zmq.sugar.Socket, so the various `await sock`s fail type checks (rightly so).

pyzmq 23 expands its type coverage, revealing these bugs in the type annotations here (#182)