### PR TITLE
Await zmq sends

### DIFF
--- a/plugins/kernels/fps_kernels/kernel_server/message.py
+++ b/plugins/kernels/fps_kernels/kernel_server/message.py
@@ -92,15 +92,15 @@ def feed_identities(msg_list: List[bytes]) -> Tuple[List[bytes], List[bytes]]:
     return msg_list[:idx], msg_list[idx + 1 :]  # noqa
 
 
-def send_message(msg: Dict[str, Any], sock: Socket, key: str) -> None:
-    sock.send_multipart(serialize(msg, key), copy=True)
+async def send_message(msg: Dict[str, Any], sock: Socket, key: str) -> None:
+    await sock.send_multipart(serialize(msg, key), copy=True)
 
 
-def send_raw_message(parts: List[bytes], sock: Socket, key: str) -> None:
+async def send_raw_message(parts: List[bytes], sock: Socket, key: str) -> None:
     msg = parts[:4]
     buffers = parts[4:]
     to_send = [DELIM, sign(msg, key)] + msg + buffers
-    sock.send_multipart(to_send)
+    await sock.send_multipart(to_send)
 
 
 def deserialize_msg_from_ws_v1(ws_msg: bytes) -> Tuple[str, List[bytes]]:

--- a/plugins/kernels/fps_kernels/kernel_server/server.py
+++ b/plugins/kernels/fps_kernels/kernel_server/server.py
@@ -172,7 +172,7 @@ class KernelServer:
     async def _wait_for_ready(self):
         while True:
             msg = create_message("kernel_info_request")
-            send_message(msg, self.shell_channel, self.key)
+            await send_message(msg, self.shell_channel, self.key)
             msg = await receive_message(self.shell_channel, 0.2)
             if msg is not None and msg["msg_type"] == "kernel_info_reply":
                 msg = await receive_message(self.iopub_channel, 0.2)
@@ -193,11 +193,11 @@ class KernelServer:
                     continue
                 channel = msg.pop("channel")
                 if channel == "shell":
-                    send_message(msg, self.shell_channel, self.key)
+                    await send_message(msg, self.shell_channel, self.key)
                 elif channel == "control":
-                    send_message(msg, self.control_channel, self.key)
+                    await send_message(msg, self.control_channel, self.key)
                 elif channel == "stdin":
-                    send_message(msg, self.stdin_channel, self.key)
+                    await send_message(msg, self.stdin_channel, self.key)
         elif websocket.accepted_subprotocol == "v1.kernel.websocket.jupyter.org":
             while True:
                 msg = await websocket.websocket.receive_bytes()
@@ -211,11 +211,11 @@ class KernelServer:
                 ):
                     continue
                 if channel == "shell":
-                    send_raw_message(parts, self.shell_channel, self.key)
+                    await send_raw_message(parts, self.shell_channel, self.key)
                 elif channel == "control":
-                    send_raw_message(parts, self.control_channel, self.key)
+                    await send_raw_message(parts, self.control_channel, self.key)
                 elif channel == "stdin":
-                    send_raw_message(parts, self.stdin_channel, self.key)
+                    await send_raw_message(parts, self.stdin_channel, self.key)
 
     async def send_to_ws(self, websocket, parts, parent_header, channel_name):
         if not websocket.accepted_subprotocol:


### PR DESCRIPTION
asyncio zmq sends return awaitables, even though they _usually_ return a completed Future, due to optimizations.

Otherwise, we're creating and not awaiting Futures, which can cause ordering problems.

The layering means there are now two additional awaits for a likely already-done future. I don't know the performance cost of that. But if you care to optimize the awaits, you can do:

```python
def send_message(sock) -> Awaitable[Any]:
    return sock.send(...)

...
awaitable = send_message(sock)
f = asyncio.ensure_future(awaitable) # no-op because it's already a Future, but could be a coroutine in the future
if not f.done():
    await f
# most of the time, get here with zero awaits
```

An extra await _can_ be avoided by changing the type to `->Awaitable[Any]` and `return sock.send...`, if that's preferable.

Found while looking at #183 