### PR TITLE
Disable Windows for test_rest_api

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import sys
 
 import pytest
 import requests
@@ -47,6 +48,10 @@ def test_settings_persistence_get(start_jupyverse):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("auth_mode", ("noauth",))
 @pytest.mark.parametrize("clear_users", (False,))
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="Issue with POST /api/sessions",
+)
 async def test_rest_api(start_jupyverse):
     url = start_jupyverse
     ws_url = url.replace("http", "ws", 1)


### PR DESCRIPTION
There seems to be an issue with the POST `/api/sessions` request.