### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/python-3
+{
+  "name": "Python 3",
+  "image": "mcr.microsoft.com/vscode/devcontainers/python:3.10",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.linting.enabled": true,
+        "python.linting.pylintEnabled": true,
+        "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+        "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+        "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+        "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+        "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+        "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+        "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+        "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+        "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+      },
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [8000],
+
+  "postCreateCommand": "pip install -r .devcontainer/requirements.txt",
+  "runArgs": ["--userns=keep-id"],
+
+  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,Z",
+  "workspaceFolder": "/workspace"
+}

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -3,14 +3,12 @@
 ./plugins/contents
 ./plugins/jupyterlab
 ./plugins/kernels
-./plugins/lab
+./plugins/jupyterlab
+./plugins/login
+./plugins/terminals
 ./plugins/nbconvert
 ./plugins/yjs
-fps[unicorn]
-ipykernel
-jupyter_ydoc >=0.1.16<0.2.0
+fps[unicorn] >=0.0.10
 mypy
 pytest
 pytest-asyncio
-requests
-y-py >=0.5.4

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,0 +1,16 @@
+.
+fps[unicorn]
+./plugins/auth
+./plugins/contents
+./plugins/kernels
+./plugins/nbconvert
+./plugins/yjs
+./plugins/lab
+./plugins/jupyterlab
+jupyter_ydoc >=0.1.16<0.2.0
+y-py >=0.5.4
+mypy
+pytest
+pytest-asyncio
+requests
+ipykernel

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -2,7 +2,6 @@
 ./plugins/auth
 ./plugins/contents
 ./plugins/jupyterlab
-./plugins/jupyterlab
 ./plugins/kernels
 ./plugins/login
 ./plugins/nbconvert

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,16 +1,16 @@
 .
-fps[unicorn]
 ./plugins/auth
 ./plugins/contents
+./plugins/jupyterlab
 ./plugins/kernels
+./plugins/lab
 ./plugins/nbconvert
 ./plugins/yjs
-./plugins/lab
-./plugins/jupyterlab
+fps[unicorn]
+ipykernel
 jupyter_ydoc >=0.1.16<0.2.0
-y-py >=0.5.4
 mypy
 pytest
 pytest-asyncio
 requests
-ipykernel
+y-py >=0.5.4

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -2,11 +2,11 @@
 ./plugins/auth
 ./plugins/contents
 ./plugins/jupyterlab
-./plugins/kernels
 ./plugins/jupyterlab
+./plugins/kernels
 ./plugins/login
-./plugins/terminals
 ./plugins/nbconvert
+./plugins/terminals
 ./plugins/yjs
 fps[unicorn] >=0.0.10
 mypy


### PR DESCRIPTION
PR adds configuration to enable using [devcontainers](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/introduction-to-dev-containers) with this repository.

They're still relatively new so a brief explanation if you haven't heard of them is that devcontainers define the configuration of a development environment which can run inside Docker (or drop-in replacements like Podman), along with information on interactions with the environment (like automatic port-forwarding of services). They make it easier for developers to get started working on a project, and help get rid of some of the issues/hard to solve bugs that come from people setting up their environments in different ways.

GitHub supports them natively via Codespaces, VSCode does as well (when opening the repo in vscode, if you have the container development extension, you get a prompt to build and re-open vscode in the container), other editors also have support via plugins (e.g. [neovim](https://github.com/esensar/nvim-dev-container)).

Not sure if this would fit with the development workflow of others here so feel free to say no :P but I think it's pretty helpful to have when there are a lot of requirements, and especially when services are exposed via ports.