### PR TITLE
Remove Podman specific `runArgs`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,8 @@
   "forwardPorts": [8000],
 
   "postCreateCommand": "pip install -r .devcontainer/requirements.txt",
-  "runArgs": ["--userns=keep-id"],
+  // Uncomment runArgs if using Podman instead of Docker to ensure correct file permissions
+  // "runArgs": ["--userns=keep-id"],
 
   // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,Z",


### PR DESCRIPTION
After #207 was merged I went to check if codespaces were working and there was an error as I left a podman-only command run argument in the configuration.

In the docs it's [recommended to use this configuration](https://code.visualstudio.com/remote/advancedcontainers/docker-options#_podman) when running with rootless podman, but it isn't compatible with docker, which most people (and the online based codespaces) use, so this patch comments it out and adds an explanation.