### PR TITLE
Automated Changelog Entry for 0.0.41 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.0.41
+
+No merged PRs
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.0.40
 
 ([Full Changelog](https://github.com/jupyter-server/jupyverse/compare/v0.0.38...2f4a777357a2a94346270c259ff0953c084d30c5))
@@ -16,8 +22,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyverse/graphs/contributors?from=2022-09-06&to=2022-09-16&type=c))
 
 [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyverse+involves%3Adavidbrochart+updated%3A2022-09-06..2022-09-16&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.0.39
 


### PR DESCRIPTION
Automated Changelog Entry for 0.0.41 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyter-server/jupyverse/releases/tag/untagged-ec2b55468d71d62be483  |
| Since | v0.0.40 |