### PR TITLE
Adds base implementation of auth in auth_base

### DIFF
--- a/plugins/auth/fps_auth/models.py
+++ b/plugins/auth/fps_auth/models.py
@@ -1,15 +1,11 @@
 import uuid
-from typing import Dict, List, Optional
+from typing import Optional
 
 from fastapi_users import schemas
-from pydantic import BaseModel
+from fps_auth_base.models import BaseUser  # type: ignore
 
 
-class Permissions(BaseModel):
-    permissions: Dict[str, List[str]]
-
-
-class JupyterUser(Permissions):
+class JupyterUser(BaseUser):
     anonymous: bool = True
     username: str = ""
     name: str = ""

--- a/plugins/auth/fps_auth/routes.py
+++ b/plugins/auth/fps_auth/routes.py
@@ -6,6 +6,7 @@ from fastapi_users.exceptions import UserAlreadyExists
 from fps.config import get_config  # type: ignore
 from fps.hooks import register_router  # type: ignore
 from fps.logging import get_configured_logger  # type: ignore
+from fps_auth_base.models import Permissions  # type: ignore
 from fps_uvicorn.cli import add_query_params  # type: ignore
 from fps_uvicorn.config import UvicornConfig  # type: ignore
 from sqlalchemy import select  # type: ignore
@@ -27,7 +28,7 @@ from .db import (
     get_user_db,
     secret,
 )
-from .models import Permissions, UserCreate, UserRead, UserUpdate
+from .models import UserCreate, UserRead, UserUpdate
 
 logger = get_configured_logger("auth")
 

--- a/plugins/auth/pyproject.toml
+++ b/plugins/auth/pyproject.toml
@@ -6,9 +6,17 @@ build-backend = "hatchling.build"
 name = "fps_auth"
 description = "An FPS plugin for the authentication API"
 keywords = [ "jupyter", "server", "fastapi", "pluggy", "plugins",]
+dynamic = ["version"]
 requires-python = ">=3.7"
-dependencies = [ "fps[uvicorn] >=0.0.17", "fps-lab", "fps-login", "aiosqlite", "fastapi-users[sqlalchemy,oauth] >=10.1.4,<11",]
-dynamic = [ "version",]
+dependencies = [
+	"fps[uvicorn] >=0.0.17",
+	"fps-auth-base",
+	"fps-lab",
+	"fps-login",
+	"aiosqlite",
+	"fastapi-users[sqlalchemy,oauth] >=10.1.4,<11"
+]
+
 [[project.authors]]
 name = "Jupyter Development Team"
 email = "jupyter@googlegroups.com"

--- a/plugins/auth_base/fps_auth_base/__init__.py
+++ b/plugins/auth_base/fps_auth_base/__init__.py
@@ -1,6 +1,9 @@
 import pkg_resources
+from fps.logging import get_configured_logger  # type: ignore
 
 __version__ = "0.0.43"
+
+logger = get_configured_logger("auth_base")
 
 auth = {ep.name: ep.load() for ep in pkg_resources.iter_entry_points(group="jupyverse_auth")}
 
@@ -9,7 +12,10 @@ try:
     current_user = auth["current_user"]
     update_user = auth["update_user"]
     websocket_auth = auth["websocket_auth"]
+
 except KeyError:
-    raise RuntimeError(
-        "An auth plugin must be installed, for instance: pip install fps-auth",
-    )
+    logger.warn("No configured auth, defaulting to noauth.")
+    from .backend import current_user  # noqa: F401
+    from .backend import update_user  # noqa: F401
+    from .backend import websocket_auth  # noqa: F401
+    from .models import BaseUser as User  # noqa: F401

--- a/plugins/auth_base/fps_auth_base/backend.py
+++ b/plugins/auth_base/fps_auth_base/backend.py
@@ -1,0 +1,40 @@
+import uuid
+from typing import Any, Dict, List, Optional, Tuple
+
+from fastapi import Depends, Response, WebSocket
+
+from .models import BaseUser
+
+GLOBAL_USER = str(uuid.uuid4())
+
+
+def current_user(permissions: Optional[Dict[str, List[str]]] = None):
+    async def _(response: Response) -> Dict[str, Any]:
+        return dict(username=GLOBAL_USER, permissions={})
+
+    return _
+
+
+def websocket_auth(permissions: Optional[Dict[str, List[str]]] = None):
+    """
+    A function returning a dependency for the WebSocket connection.
+
+    :param permissions: the permissions the user should be granted access to. The user should have
+    access to at least one of them for the WebSocket to be opened.
+    :returns: a dependency for the WebSocket connection. The dependency returns a tuple consisting
+    of the websocket and the checked user permissions if the websocket is accepted, None otherwise.
+    """
+
+    async def _(
+        websocket: WebSocket,
+    ) -> Optional[Tuple[WebSocket, Optional[Dict[str, List[str]]]]]:
+        return websocket, permissions
+
+    return _
+
+
+async def update_user(user: BaseUser = Depends(current_user())):
+    async def _(data: Dict[str, Any]) -> BaseUser:
+        return user
+
+    return _

--- a/plugins/auth_base/fps_auth_base/models.py
+++ b/plugins/auth_base/fps_auth_base/models.py
@@ -1,0 +1,11 @@
+from typing import Dict, List
+
+from pydantic import BaseModel
+
+
+class Permissions(BaseModel):
+    permissions: Dict[str, List[str]]
+
+
+class BaseUser(Permissions):
+    username: str = ""

--- a/plugins/auth_base/pyproject.toml
+++ b/plugins/auth_base/pyproject.toml
@@ -7,7 +7,7 @@ name = "fps_auth_base"
 description = "An FPS plugin for the authentication API"
 keywords = [ "jupyter", "server", "fastapi", "pluggy", "plugins",]
 requires-python = ">=3.7"
-dependencies = ["fps >=0.0.17"]
+dependencies = ["fps>=0.0.17"]
 dynamic = [ "version",]
 
 [[project.authors]]

--- a/plugins/auth_fief/fps_auth_fief/models.py
+++ b/plugins/auth_fief/fps_auth_fief/models.py
@@ -1,13 +1,9 @@
-from typing import Dict, List, Optional
+from typing import Optional
 
-from pydantic import BaseModel
-
-
-class Permissions(BaseModel):
-    permissions: Dict[str, List[str]]
+from fps_auth_base.models import BaseUser
 
 
-class UserRead(BaseModel):
+class UserRead(BaseUser):
     username: str = ""
     name: str = ""
     display_name: str = ""

--- a/plugins/auth_fief/fps_auth_fief/routes.py
+++ b/plugins/auth_fief/fps_auth_fief/routes.py
@@ -4,9 +4,10 @@ from fastapi import APIRouter, Depends, Query, Request, Response
 from fastapi.responses import RedirectResponse
 from fief_client import FiefAccessTokenInfo
 from fps.hooks import register_router
+from fps_auth_base.models import Permissions
 
 from .backend import SESSION_COOKIE_NAME, auth, current_user, fief
-from .models import Permissions, UserRead
+from .models import UserRead
 
 router = APIRouter()
 

--- a/plugins/auth_fief/pyproject.toml
+++ b/plugins/auth_fief/pyproject.toml
@@ -6,9 +6,14 @@ build-backend = "hatchling.build"
 name = "fps_auth_fief"
 description = "An FPS plugin for the authentication API, using Fief"
 keywords = [ "jupyter", "server", "fastapi", "pluggy", "plugins",]
+dynamic = ["version"]
 requires-python = ">=3.7"
-dependencies = [ "fps >=0.0.8", "fief-client[fastapi]",]
-dynamic = [ "version",]
+dependencies = [
+	"fief-client[fastapi]",
+	"fps >=0.0.8",
+	"fps-auth-base"
+]
+
 [[project.authors]]
 name = "Jupyter Development Team"
 email = "jupyter@googlegroups.com"


### PR DESCRIPTION
Follow-up #232 

The problem is that if we want to reuse, for example, `fps-kernel` somewhere else, `fps-kernels` depends on `fps-auth-base` because it needs an implementation of auth, but `fps-auth-base` doesn't include a default implementation.

This PR fixes this problem by implementing a default authorization that allows everything and always returns the same user.
At the same time, it implements a BaseUser class that other authorization plugins can extend.


I noticed that the `fps-auth` plugin depends on `fps-login`, and the `fps-login` imports configuration from `fps-auth`. Since the `fps-login` plugin is a login page made ad-hoc for `fps-auth`, maybe should move it to `fps-auth`.