### PR TITLE
Use system prefix instead of conda prefix for kernel test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
     branches:
     - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,12 +24,15 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+
+    - name: Upgrade pip
+      run: python3 -m pip install --upgrade pip
 
     - name: Install jupyverse
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,15 +26,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup conda
-      uses: conda-incubator/setup-miniconda@v2
+    - uses: actions/setup-python@v4
       with:
-        activate-environment: jupyverse-dev
-        environment-file: dev-environment.yml
         python-version: ${{ matrix.python-version }}
-        mamba-version: "*"
-        auto-activate-base: false
-        channels: conda-forge
+        cache: 'pip'
 
     - name: Install jupyverse
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,6 @@ on:
     branches:
     - main
 
-defaults:
-  run:
-    shell: bash -l {0}
-
 jobs:
   test:
     name: Test

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -1,5 +1,0 @@
-name: jupyverse-dev
-channels:
-    - conda-forge
-dependencies:
-    - pip

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from pathlib import Path
 from time import sleep

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -20,9 +20,7 @@ async def test_kernel_messages(client, capfd):
         Path(sys.prefix) / "share" / "jupyter" / "kernels" / kernel_name / "kernel.json"
     )
     assert kernelspec_path.exists()
-    kernel_server = KernelServer(
-        kernelspec_path=kernelspec_path, capture_kernel_output=False
-    )
+    kernel_server = KernelServer(kernelspec_path=kernelspec_path, capture_kernel_output=False)
     await kernel_server.start()
     kernels[kernel_id] = {"server": kernel_server}
     msg_id = "0"

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from pathlib import Path
 from time import sleep
 
 import pytest
@@ -16,9 +17,12 @@ async def test_kernel_messages(client, capfd):
     kernel_id = "kernel_id_0"
     kernel_name = "python3"
     kernelspec_path = (
-        os.environ["CONDA_PREFIX"] + f"/share/jupyter/kernels/{kernel_name}/kernel.json"
+        Path(sys.prefix) / "share" / "jupyter" / "kernels" / kernel_name / "kernel.json"
     )
-    kernel_server = KernelServer(kernelspec_path=kernelspec_path, capture_kernel_output=False)
+    assert kernelspec_path.exists()
+    kernel_server = KernelServer(
+        kernelspec_path=kernelspec_path, capture_kernel_output=False
+    )
     await kernel_server.start()
     kernels[kernel_id] = {"server": kernel_server}
     msg_id = "0"


### PR DESCRIPTION
One of the tests assumes that conda was used to create the environment jupyverse is running in as it the path to the kernel is set to `os.environ["CONDA_PREFIX"] / "share/.../kernel.json"`, which will error out if `CONDA_PREFIX` is not set.

PR changes the kernelspec path to use `sys.prefix` instead of the `CONDA_PREFIX` env var. When running out of a virtual environment (be it native python venv or a conda environment) `sys.prefix` will point to the prefix for that virtual environment, not the actual system prefix.

Since `CONDA_PREFIX` is equivalent to `sys.prefix`, this doesn't change anything for that case, but lets the tests pass when running in a native python venv.

This is related to https://github.com/jupyter-server/jupyverse/pull/239 as running tests locally with hatch environments would fail always fail `test_kernel_messages`.

Also, the full miniconda setup is quite heavy, so I replaced it with the lighter `actions/setup-python`. Since the conda environment was just used to set up python moving to this action shouldn't have an effect on the tests, but might help speed up the setup process a bit, especially since I enabled reusing the pip cache between CI runs.