### PR TITLE
Fix clean room never triggered

### DIFF
--- a/plugins/yjs/fps_yjs/routes.py
+++ b/plugins/yjs/fps_yjs/routes.py
@@ -191,7 +191,7 @@ class YDocWebSocketHandler:
                 self.room.document.observe(self.on_document_change)
 
         await self.websocket_server.serve(self.websocket)
-        if not self.room.is_transient and self.room.clients == [self.websocket]:
+        if not self.room.is_transient and not self.room.clients:
             # no client in this room after we disconnect
             # keep the document for a while in case someone reconnects
             self.room.cleaner = asyncio.create_task(self.clean_room())


### PR DESCRIPTION
The `client` is removed here, and the `websocket` should no longer be judged to exist in the `clients`
https://github.com/y-crdt/ypy-websocket/blob/main/ypy_websocket/websocket_server.py#L147