### PR TITLE
Fix contents for empty directory

### DIFF
--- a/jupyverse_api/jupyverse_api/contents/models.py
+++ b/jupyverse_api/jupyverse_api/contents/models.py
@@ -13,7 +13,7 @@ class Content(BaseModel):
     path: str
     last_modified: Optional[str]
     created: Optional[str]
-    content: Optional[Union[str, Dict, List[Dict]]]
+    content: Optional[Union[List[Dict], str, Dict]]
     format: Optional[str]
     mimetype: Optional[str]
     size: Optional[int]


### PR DESCRIPTION
Without this fix, one cannot enter an empty directory because the returned `content` is `{}` instead of `[]`.
Pydantic uses the first type in a `Union` that matches (see [documentation](https://docs.pydantic.dev/latest/usage/types/#unions)).
It seems that [smart_union](https://docs.pydantic.dev/latest/usage/model_config/#smart-union) works with Pydantic but not with FastAPI, so I just moved the `List` to the first type.