### PR TITLE
Fix multiple sessions in one kernel bug

### DIFF
--- a/plugins/kernels/fps_kernels/routes.py
+++ b/plugins/kernels/fps_kernels/routes.py
@@ -178,6 +178,7 @@ class _Kernels(Kernels):
                 kernel_cwd=str(kernel_cwd),
             )
             kernel_id = str(uuid.uuid4())
+            self.kernel_id_to_connection_file[kernel_id] = kernel_server.connection_file_path
             kernels[kernel_id] = {"name": kernel_name, "server": kernel_server, "driver": None}
             await kernel_server.start()
         elif kernel_id is not None:

--- a/plugins/kernels/fps_kernels/routes.py
+++ b/plugins/kernels/fps_kernels/routes.py
@@ -182,13 +182,12 @@ class _Kernels(Kernels):
             kernels[kernel_id] = {"name": kernel_name, "server": kernel_server, "driver": None}
             await kernel_server.start()
         elif kernel_id is not None:
-            # external kernel
+            # already running kernel
             kernel_name = kernels[kernel_id]["name"]
             kernel_server = KernelServer(
                 connection_file=self.kernel_id_to_connection_file[kernel_id],
                 write_connection_file=False,
             )
-            kernels[kernel_id]["server"] = kernel_server
             await kernel_server.start(launch_kernel=False)
         else:
             return


### PR DESCRIPTION
I found the following error

### How to reproduce the bug?

1. Run jupyverse jupyterlab
2. Create a session for the kernel. The kernel itself will start and a session will be created for it.
3. Add another session to the running kernel.

#### Expected behavior

The session will be added

####  Actual behavior

Error (see below).

https://github.com/user-attachments/assets/a47f360f-531f-4122-8edf-e0cdde1a8052

```
  File "/home/rakhmaevao/Projects/jupyverse/plugins/kernels/fps_kernels/routes.py", line 187, in create_session
    connection_file=self.kernel_id_to_connection_file[kernel_id],
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: '68527f9d-7362-4c0a-ac66-d9e429a78246'
```

### How did I fix it?

1. After creating a new kernel (see step 2 of the instructions for reproducing the bug), I added the path to CONNFILE to the mapping. This allowed me to find the path to this file when starting a new session.
2. Additionally, I fixed the kernel restart when another session is created for it. The problem was that when creating an additional session, the KS was rewritten without kernelspec_path. I deleted this rewriting.

#### Confirmation of functionality


https://github.com/user-attachments/assets/bdcd4495-044a-45fd-8f1c-aac400454ef7