### PR TITLE
Fix read/write permission issue with collaboration rooms

### DIFF
--- a/plugins/yjs/fps_yjs/routes.py
+++ b/plugins/yjs/fps_yjs/routes.py
@@ -29,8 +29,8 @@ from jupyverse_api.main import Lifespan
 from jupyverse_api.yjs import Yjs
 from jupyverse_api.yjs.models import CreateDocumentSession
 
-from .ywebsocket.websocket_server import WebsocketServer, YRoom
 from .ywebsocket.websocket import Websocket
+from .ywebsocket.websocket_server import WebsocketServer, YRoom
 from .ywebsocket.ystore import SQLiteYStore, YDocNotFound
 from .ywidgets import Widgets
 

--- a/plugins/yjs/fps_yjs/routes.py
+++ b/plugins/yjs/fps_yjs/routes.py
@@ -164,6 +164,7 @@ class RoomManager:
     cleaners: dict[YRoom, Task]
     last_modified: dict[str, datetime]
     websocket_server: JupyterWebsocketServer
+    room_write_permissions: dict[str, set[YWebsocket]]
     room_lock: ResourceLock
 
     def __init__(self, contents: Contents, file_id: FileId, lifespan: Lifespan):

--- a/plugins/yjs/fps_yjs/routes.py
+++ b/plugins/yjs/fps_yjs/routes.py
@@ -201,6 +201,9 @@ class RoomManager:
                 self.room_write_permissions[websocket.path] = set()
             if can_write:
                 self.room_write_permissions[websocket.path].add(websocket)
+            else:
+                self.room_write_permissions[websocket.path].discard(websocket)
+            
             room.on_message = self.filter_message
             is_stored_document = websocket.path.count(":") >= 2
             if is_stored_document:
@@ -411,6 +414,10 @@ class RoomManager:
                 del self.watchers[file_id]
         room_name = self.websocket_server.get_room_name(room)
         self.websocket_server.delete_room(room=room)
+
+        if ws_path in self.room_write_permissions:
+            del self.room_write_permissions[ws_path]
+            
         file_path = await self.get_file_path(file_id, document)
         logger.info("Closing collaboration room", room_id=room_name, file_path=file_path)
         if room in self.cleaners:

--- a/plugins/yjs/fps_yjs/routes.py
+++ b/plugins/yjs/fps_yjs/routes.py
@@ -203,7 +203,7 @@ class RoomManager:
                 self.room_write_permissions[websocket.path].add(websocket)
             else:
                 self.room_write_permissions[websocket.path].discard(websocket)
-            
+
             room.on_message = self.filter_message
             is_stored_document = websocket.path.count(":") >= 2
             if is_stored_document:
@@ -417,7 +417,7 @@ class RoomManager:
 
         if ws_path in self.room_write_permissions:
             del self.room_write_permissions[ws_path]
-            
+
         file_path = await self.get_file_path(file_id, document)
         logger.info("Closing collaboration room", room_id=room_name, file_path=file_path)
         if room in self.cleaners:

--- a/plugins/yjs/fps_yjs/routes.py
+++ b/plugins/yjs/fps_yjs/routes.py
@@ -296,7 +296,6 @@ class RoomManager:
         else:
             skip = True
 
-        print(skip)
         return skip
 
     async def get_file_path(self, file_id: str, document) -> str | None:

--- a/plugins/yjs/fps_yjs/routes.py
+++ b/plugins/yjs/fps_yjs/routes.py
@@ -175,7 +175,7 @@ class RoomManager:
         self.savers = {}  # a dictionary of file_id:task
         self.cleaners = {}  # a dictionary of room:task
         self.last_modified = {}  # a dictionary of file_id:last_modification_date
-        self.room_write_permissions = {}  # a dictionary of room_name:set of websockets that can write
+        self.room_write_permissions = {}  # a dictionary of room_name:websockets that can write
         self.websocket_server = JupyterWebsocketServer(rooms_ready=False, auto_clean_rooms=False)
         self.room_lock = ResourceLock()
 

--- a/plugins/yjs/fps_yjs/routes.py
+++ b/plugins/yjs/fps_yjs/routes.py
@@ -202,8 +202,6 @@ class RoomManager:
                 self.room_write_permissions[websocket.path] = set()
             if can_write:
                 self.room_write_permissions[websocket.path].add(websocket)
-            else:
-                self.room_write_permissions[websocket.path].discard(websocket)
 
             room.on_message = self.filter_message
             is_stored_document = websocket.path.count(":") >= 2
@@ -269,6 +267,9 @@ class RoomManager:
                             )
 
         await self.websocket_server.serve(websocket, self.lifespan.shutdown_request)
+
+        if websocket in self.room_write_permissions.get(websocket.path, set()):
+            self.room_write_permissions[websocket.path].remove(websocket)
 
         if not self.lifespan.shutdown_request.is_set() and is_stored_document and not room.clients:
             # no client in this room after we disconnect

--- a/plugins/yjs/fps_yjs/ywebsocket/yroom.py
+++ b/plugins/yjs/fps_yjs/ywebsocket/yroom.py
@@ -34,7 +34,7 @@ class YRoom:
     clients: list
     ydoc: Doc
     ystore: BaseYStore | None
-    _on_message: Callable[[bytes], Awaitable[bool] | bool] | None
+    _on_message: Callable[[bytes, Websocket], Awaitable[bool] | bool] | None
     _update_send_stream: MemoryObjectSendStream
     _update_receive_stream: MemoryObjectReceiveStream
     _ready: bool
@@ -109,7 +109,7 @@ class YRoom:
             self.ydoc.observe(partial(put_updates, self._update_send_stream))
 
     @property
-    def on_message(self) -> Callable[[bytes], Awaitable[bool] | bool] | None:
+    def on_message(self) -> Callable[[bytes, Websocket], Awaitable[bool] | bool] | None:
         """
         Returns:
             The optional callback to call when a message is received.
@@ -117,7 +117,7 @@ class YRoom:
         return self._on_message
 
     @on_message.setter
-    def on_message(self, value: Callable[[bytes], Awaitable[bool] | bool] | None):
+    def on_message(self, value: Callable[[bytes, Websocket], Awaitable[bool] | bool] | None):
         """
         Arguments:
             value: An optional callback to call when a message is received.
@@ -210,7 +210,7 @@ class YRoom:
                     # filter messages (e.g. awareness)
                     skip = False
                     if self.on_message:
-                        _skip = self.on_message(message)
+                        _skip = self.on_message(message, websocket)
                         skip = await _skip if isawaitable(_skip) else _skip
                     if skip:
                         continue


### PR DESCRIPTION
Fixes the issue described in https://github.com/jupyter-server/jupyverse/issues/505.

## Testing method

I modified no-auth locally to remove the yjs write permission, unless if the request had a `yjs-write` header. Then, I opened two browsers, one on `localhost:8000`, connecting directly to the web server (read-only), and another on `localhost:8001`, connecting to a proxy that attached the `yjs-write` header. (read-write).

 

https://github.com/user-attachments/assets/d74ad39f-7f2e-4fea-8578-45bd309f6c01


