### PR TITLE
Support separate kernel environment

### DIFF
--- a/jupyverse_api/jupyverse_api/kernels/__init__.py
+++ b/jupyverse_api/jupyverse_api/kernels/__init__.py
@@ -251,3 +251,4 @@ class KernelsConfig(Config):
         default=None,
     )
     require_yjs: bool = False
+    kernelenv_path: str = ""

--- a/plugins/kernel_subprocess/fps_kernel_subprocess/kernel_subprocess.py
+++ b/plugins/kernel_subprocess/fps_kernel_subprocess/kernel_subprocess.py
@@ -97,6 +97,7 @@ class KernelSubprocess(Kernel):
                         f"micromamba activate {env_name};" + \
                         " ".join(launch_kernel_cmd) + "' & echo $!"
                     process = await open_process(cmd)
+                    assert process.stdout is not None
                     async for text in TextReceiveStream(process.stdout):
                         self._pid = int(text)
                         break

--- a/plugins/kernel_subprocess/fps_kernel_subprocess/kernel_subprocess.py
+++ b/plugins/kernel_subprocess/fps_kernel_subprocess/kernel_subprocess.py
@@ -88,7 +88,7 @@ class KernelSubprocess(Kernel):
                 if await path.is_file():
                     kernelenv = await path.read_text()
             if kernelenv:
-                import yaml
+                import yaml  # type: ignore[import-untyped]
                 env_name = yaml.load(kernelenv, Loader=yaml.CLoader)["name"]
                 cmd = f"micromamba create -f {self.kernelenv_path} --yes"
                 result = await run_process(cmd)

--- a/plugins/kernel_subprocess/fps_kernel_subprocess/main.py
+++ b/plugins/kernel_subprocess/fps_kernel_subprocess/main.py
@@ -10,4 +10,4 @@ from .kernel_subprocess import KernelSubprocess
 class KernelSubprocessModule(Module):
     async def prepare(self) -> None:
         default_kernel_factory = DefaultKernelFactory(KernelSubprocess)
-        self.put(default_kernel_factory, DefaultKernelFactory)
+        self.put(default_kernel_factory)

--- a/plugins/kernels/fps_kernels/kernel_server/server.py
+++ b/plugins/kernels/fps_kernels/kernel_server/server.py
@@ -52,6 +52,7 @@ class KernelServer:
         self,
         default_kernel_factory: DefaultKernelFactory,
         kernelspec_path: str = "",
+        kernelenv_path: str = "",
         kernel_cwd: str = "",
         connection_file: str = "",
         write_connection_file: bool = True,
@@ -60,6 +61,7 @@ class KernelServer:
         self.default_kernel_factory = default_kernel_factory
         self.capture_kernel_output = capture_kernel_output
         self.kernelspec_path = kernelspec_path
+        self.kernelenv_path = kernelenv_path
         self.kernel_cwd = kernel_cwd
         self.connection_file = connection_file
         self.write_connection_file = write_connection_file
@@ -109,6 +111,7 @@ class KernelServer:
                     self.kernel = self.default_kernel_factory(
                         write_connection_file=self.write_connection_file,
                         kernelspec_path=self.kernelspec_path,
+                        kernelenv_path=self.kernelenv_path,
                         connection_file=self.connection_file,
                         kernel_cwd=self.kernel_cwd,
                         capture_output=self.capture_kernel_output,
@@ -116,6 +119,7 @@ class KernelServer:
                 else:
                     self.kernel = kernel_factory(
                         kernelspec_path=self.kernelspec_path,
+                        kernelenv_path=self.kernelenv_path,
                         connection_file=self.connection_file,
                         kernel_cwd=self.kernel_cwd,
                         capture_output=self.capture_kernel_output,

--- a/plugins/kernels/fps_kernels/routes.py
+++ b/plugins/kernels/fps_kernels/routes.py
@@ -223,6 +223,7 @@ class _Kernels(Kernels):
                 kernel_cwd = kernel_cwd.parent
             kernel_server = KernelServer(
                 kernelspec_path=Path(find_kernelspec(kernel_name)).as_posix(),
+                kernelenv_path=self.kernels_config.kernelenv_path,
                 kernel_cwd=str(kernel_cwd),
                 default_kernel_factory=self.default_kernel_factory,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ pre-install-commands = [
   "pip install -e ./plugins/auth_jupyterhub",
   "pip install -e ./plugins/jupyterlab",
   "pip install -e ./plugins/notebook",
+  "pip install pyyaml",
 ]
 features = ["test"]
 


### PR DESCRIPTION
This allows to run kernels in an environment that is separate from the environment the server is running in.
Currently, only conda environments are supported, and the only supported package manager is [micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html). Also, the only supported shell is bash. Note that [pyyaml](https://pyyaml.org) must be installed in the server environment.
A path to a environment must be passed like so:
```bash
jupyverse --set kernels.kernelenv_path=environment.yml
```