### PR TITLE
Filter SYNC_STEP2 messages from read-only clients

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install hatch
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install hatch
+        python3 -m pip install hatch "click <8.3.0"
     - name: Check types
       run: |
         hatch run dev:typecheck
@@ -52,7 +52,7 @@ jobs:
     - name: Install hatch
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install hatch
+        python3 -m pip install hatch "click <8.3.0"
 
     - name: Run tests
       run: hatch run dev:test

--- a/plugins/yjs/fps_yjs/routes.py
+++ b/plugins/yjs/fps_yjs/routes.py
@@ -303,7 +303,10 @@ class RoomManager:
             # skip = True
             pass
         elif byte == YMessageType.SYNC:
-            if not can_write and msg[0] == YSyncMessageType.SYNC_UPDATE:
+            if not can_write and msg[0] in {
+                YSyncMessageType.SYNC_UPDATE,
+                YSyncMessageType.SYNC_STEP2,
+            }:
                 skip = True
         else:
             skip = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ keywords = ["jupyter", "server", "fastapi", "plugins"]
 requires-python = ">=3.9"
 dependencies = [
     "fps[click,fastapi,anycorn] >=0.5.2,<0.6.0",
+    "click <8.3.0",
     "fps-contents >=0.10.2,<0.11.0",
     "fps-file-id >=0.3.3,<0.4.0",
     "fps-file-watcher >=0.1.2,<0.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ keywords = ["jupyter", "server", "fastapi", "plugins"]
 requires-python = ">=3.9"
 dependencies = [
     "fps[click,fastapi,anycorn] >=0.5.2,<0.6.0",
-    "click <8.3.0",
     "fps-contents >=0.10.2,<0.11.0",
     "fps-file-id >=0.3.3,<0.4.0",
     "fps-file-watcher >=0.1.2,<0.2.0",


### PR DESCRIPTION
It's possible for a read-only client to make changes to a collaborative document through `SYNC_STEP2` messages, since the server only filters out `SYNC_UPDATE` types.

Minimal repro:
- Connect to room as read-only
- Make changes to local document (updates get filtered out)
- Disconnect and re-connect to the room, changes are now accepted by the server

https://github.com/user-attachments/assets/d8001a43-e174-420a-b464-6a1966ad1dae

This PR fixes that issue and makes the server also filter `SYNC_STEP2` messages from read-only clients.

