### PR TITLE
feat: make waiting for kernel environment creation optional via config

### DIFF
--- a/jupyverse_api/src/jupyverse_api/kernels/__init__.py
+++ b/jupyverse_api/src/jupyverse_api/kernels/__init__.py
@@ -250,3 +250,4 @@ class KernelsConfig(Config):
     )
     require_yjs: bool = False
     kernelenv_path: str = ""
+    wait_for_kernelenv: bool = False

--- a/jupyverse_api/src/jupyverse_api/kernels/__init__.py
+++ b/jupyverse_api/src/jupyverse_api/kernels/__init__.py
@@ -250,4 +250,9 @@ class KernelsConfig(Config):
     )
     require_yjs: bool = False
     kernelenv_path: str = ""
-    wait_for_kernelenv: bool = False
+    wait_for_kernelspec: bool = Field(
+        description=(
+            "Whether to wait for the kernelspec file to be present when launching a kernel."
+        ),
+        default=False,
+    )

--- a/plugins/kernels/src/fps_kernels/routes.py
+++ b/plugins/kernels/src/fps_kernels/routes.py
@@ -229,7 +229,7 @@ class _Kernels(Kernels):
                     break
                 kernel_cwd = kernel_cwd.parent
             kernelspec_path = anyio.Path(find_kernelspec(kernel_name))
-            if self.kernels_config.wait_for_kernelenv:
+            if self.kernels_config.wait_for_kernelspec:
                 while True:
                     if await kernelspec_path.is_file():
                         break

--- a/plugins/kernels/src/fps_kernels/routes.py
+++ b/plugins/kernels/src/fps_kernels/routes.py
@@ -231,7 +231,7 @@ class _Kernels(Kernels):
             kernelspec_path = anyio.Path(find_kernelspec(kernel_name))
             if self.kernels_config.wait_for_kernelenv:
                 while True:
-                    if not await kernelspec_path.is_dir():
+                    if await kernelspec_path.is_file():
                         break
                     logger.info("Waiting for kernelspec", kernel_name=kernel_name)
                     await sleep(1)

--- a/plugins/kernels/src/fps_kernels/routes.py
+++ b/plugins/kernels/src/fps_kernels/routes.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import anyio
 import structlog
-from anyio import TASK_STATUS_IGNORED, Event, Lock, create_task_group, open_file
+from anyio import TASK_STATUS_IGNORED, Event, Lock, create_task_group, open_file, sleep
 from anyio.abc import TaskStatus
 from fastapi import HTTPException, Response
 from fastapi.responses import FileResponse
@@ -228,8 +228,16 @@ class _Kernels(Kernels):
                 if kernel_cwd.is_dir():
                     break
                 kernel_cwd = kernel_cwd.parent
+            kernelspec_path = anyio.Path(find_kernelspec(kernel_name))
+            if self.kernels_config.wait_for_kernelenv:
+                while True:
+                    logger.info("Waiting for kernelspec", kernel_name=kernel_name)
+                    if not await kernelspec_path.is_dir():
+                        break
+                    await sleep(1)
+                    kernelspec_path = anyio.Path(find_kernelspec(kernel_name))
             kernel_server = KernelServer(
-                kernelspec_path=Path(find_kernelspec(kernel_name)).as_posix(),
+                kernelspec_path=kernelspec_path.as_posix(),
                 kernelenv_path=self.kernels_config.kernelenv_path,
                 kernel_cwd=str(kernel_cwd),
                 default_kernel_factory=self.default_kernel_factory,

--- a/plugins/kernels/src/fps_kernels/routes.py
+++ b/plugins/kernels/src/fps_kernels/routes.py
@@ -231,9 +231,9 @@ class _Kernels(Kernels):
             kernelspec_path = anyio.Path(find_kernelspec(kernel_name))
             if self.kernels_config.wait_for_kernelenv:
                 while True:
-                    logger.info("Waiting for kernelspec", kernel_name=kernel_name)
                     if not await kernelspec_path.is_dir():
                         break
+                    logger.info("Waiting for kernelspec", kernel_name=kernel_name)
                     await sleep(1)
                     kernelspec_path = anyio.Path(find_kernelspec(kernel_name))
             kernel_server = KernelServer(

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,6 +1,8 @@
+import json
 import os
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from anyio import create_task_group, sleep, sleep_forever
@@ -152,6 +154,60 @@ async def test_kernel_messages(auth_mode, capfd):
                 assert err.count("msg_type_0") >= 1
 
                 await kernel_server.stop()
+
+
+@pytest.mark.anyio
+async def test_wait_for_kernelspec(tmp_path):
+    kernel_name = "python-wait-test"
+    kernelspec_dir = tmp_path / kernel_name
+    kernelspec_json = kernelspec_dir / "kernel.json"
+
+    config = merge_config(
+        CONFIG,
+        {
+            "jupyverse": {
+                "modules": {
+                    "auth": {"config": {"mode": "noauth"}},
+                    "kernels": {"config": {"wait_for_kernelenv": True}},
+                }
+            }
+        },
+    )
+
+    root_module = get_root_module(config)
+    root_module._global_start_timeout = 10
+    with patch("fps_kernels.kernel_driver.kernelspec.kernelspec_dirs", return_value=[tmp_path]):
+        async with root_module as root_module:
+            app = root_module.app
+            transport = ASGIWebSocketTransport(app=app)
+            kernelspec_dir.mkdir(parents=True)
+
+            async def create_kernelspec_later():
+                await sleep(0.2)
+                kernel_spec = {
+                    "argv": ["python", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+                    "display_name": "Python 3",
+                    "language": "python",
+                }
+                kernelspec_json.write_text(json.dumps(kernel_spec))
+
+            async with create_task_group() as tg:
+                tg.start_soon(create_kernelspec_later)
+                async with AsyncClient(
+                    transport=transport,
+                    base_url="http://testserver",
+                ) as client:
+                    response = await client.post(
+                        "/api/sessions",
+                        json={
+                            "kernel": {"name": kernel_name},
+                            "name": "test",
+                            "path": "test.ipynb",
+                            "type": "notebook",
+                        },
+                    )
+
+            assert response.status_code == 201
 
 
 class KernelFactory:

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import sys
 from pathlib import Path
@@ -157,7 +158,7 @@ async def test_kernel_messages(auth_mode, capfd):
 
 
 @pytest.mark.anyio
-async def test_wait_for_kernelspec(tmp_path):
+async def test_wait_for_kernelspec(tmp_path, caplog):
     kernel_name = "python-wait-test"
     kernelspec_dir = tmp_path / kernel_name
     kernelspec_json = kernelspec_dir / "kernel.json"
@@ -208,6 +209,18 @@ async def test_wait_for_kernelspec(tmp_path):
                     )
 
             assert response.status_code == 201
+            with caplog.at_level(logging.INFO):
+                assert (
+                    len(
+                        [
+                            record
+                            for record in caplog.records
+                            if "Waiting for kernelspec" in record.message
+                        ]
+                    )
+                    >= 1
+                )
+                assert any(kernel_name in record.message for record in caplog.records)
 
 
 class KernelFactory:

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -169,7 +169,7 @@ async def test_wait_for_kernelspec(tmp_path, caplog):
             "jupyverse": {
                 "modules": {
                     "auth": {"config": {"mode": "noauth"}},
-                    "kernels": {"config": {"wait_for_kernelenv": True}},
+                    "kernels": {"config": {"wait_for_kernelspec": True}},
                 }
             }
         },


### PR DESCRIPTION
Optionally wait for the kernel environment to be ready before starting the kernel.
Controlled by KernelsConfig.wait_for_kernel_env (default: False)
