### PR TITLE
Fix kernelspec env

### DIFF
--- a/plugins/kernel_subprocess/src/fps_kernel_subprocess/kernel_subprocess.py
+++ b/plugins/kernel_subprocess/src/fps_kernel_subprocess/kernel_subprocess.py
@@ -80,10 +80,11 @@ class KernelSubprocess(Kernel):
             launch_kernel_cmd = [
                 s.format(connection_file=self.connection_file) for s in kernelspec["argv"]
             ]
-            # Apply the kernelspec `env` on top of the inherited environment, like
-            # jupyter_client does. Kernels such as xeus-r rely on it (R_HOME,
-            # LD_LIBRARY_PATH); without it they exit immediately at startup.
-            kernel_env = {**os.environ, **kernelspec.get("env", {})}
+            # Merge the kernelspec `env` over the inherited one, expanding
+            # variable references (e.g. "$PATH") like a shell would.
+            kernel_env = dict(os.environ)
+            for key, value in kernelspec.get("env", {}).items():
+                kernel_env[key] = os.path.expandvars(value) if isinstance(value, str) else value
             if self.capture_output:
                 stdout = subprocess.DEVNULL
                 stderr = subprocess.STDOUT

--- a/plugins/kernel_subprocess/src/fps_kernel_subprocess/kernel_subprocess.py
+++ b/plugins/kernel_subprocess/src/fps_kernel_subprocess/kernel_subprocess.py
@@ -80,6 +80,10 @@ class KernelSubprocess(Kernel):
             launch_kernel_cmd = [
                 s.format(connection_file=self.connection_file) for s in kernelspec["argv"]
             ]
+            # Apply the kernelspec `env` on top of the inherited environment, like
+            # jupyter_client does. Kernels such as xeus-r rely on it (R_HOME,
+            # LD_LIBRARY_PATH); without it they exit immediately at startup.
+            kernel_env = {**os.environ, **kernelspec.get("env", {})}
             if self.capture_output:
                 stdout = subprocess.DEVNULL
                 stderr = subprocess.STDOUT
@@ -105,7 +109,7 @@ class KernelSubprocess(Kernel):
                         + " ".join(launch_kernel_cmd)
                         + "' & echo $!"
                     )
-                    process = await open_process(cmd)
+                    process = await open_process(cmd, env=kernel_env)
                     assert process.stdout is not None
                     async for text in TextReceiveStream(process.stdout):
                         self._pid = int(text)
@@ -118,7 +122,11 @@ class KernelSubprocess(Kernel):
                 }:
                     launch_kernel_cmd[0] = sys.executable
                 self._process = await open_process(
-                    launch_kernel_cmd, stdout=stdout, stderr=stderr, cwd=kernel_cwd
+                    launch_kernel_cmd,
+                    stdout=stdout,
+                    stderr=stderr,
+                    cwd=kernel_cwd,
+                    env=kernel_env,
                 )
 
             assert self.connection_cfg is not None

--- a/plugins/kernel_subprocess/tests/test_kernel_env.py
+++ b/plugins/kernel_subprocess/tests/test_kernel_env.py
@@ -36,7 +36,7 @@ async def test_kernelspec_env_is_passed_to_kernel(tmp_path, monkeypatch):
         )
         await tg.start(kernel.start)
         try:
-            with fail_after(30):
+            with fail_after(10):
                 while not out.exists():
                     await sleep(0.1)
         finally:

--- a/plugins/kernel_subprocess/tests/test_kernel_env.py
+++ b/plugins/kernel_subprocess/tests/test_kernel_env.py
@@ -38,7 +38,7 @@ async def test_kernelspec_env_is_passed_to_kernel(tmp_path, monkeypatch):
         try:
             with fail_after(30):
                 while not out.exists():
-                    await sleep(0.05)
+                    await sleep(0.1)
         finally:
             await kernel.stop()
 

--- a/plugins/kernel_subprocess/tests/test_kernel_env.py
+++ b/plugins/kernel_subprocess/tests/test_kernel_env.py
@@ -11,7 +11,7 @@ async def test_kernelspec_env_is_passed_to_kernel(tmp_path, monkeypatch):
     # The kernel writes an env var (declared in the kernelspec `env`) to a file,
     # so we can assert the kernelspec environment actually reached the process.
     out = tmp_path / "env_seen.txt"
-    script = f"import os; open({str(out)!r}, 'w').write(os.environ.get('FPS_ENV_TEST', 'MISSING'))"
+    script = f"import os; open('{out}', 'w').write(os.environ.get('FPS_ENV_TEST', 'MISSING'))"
     kernelspec = tmp_path / "kernel.json"
     kernelspec.write_text(
         json.dumps(

--- a/plugins/kernel_subprocess/tests/test_kernel_env.py
+++ b/plugins/kernel_subprocess/tests/test_kernel_env.py
@@ -1,0 +1,45 @@
+import json
+
+import pytest
+from anyio import create_task_group, fail_after, sleep
+from fps_kernel_subprocess.kernel_subprocess import KernelSubprocess
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_kernelspec_env_is_passed_to_kernel(tmp_path, monkeypatch):
+    # The kernel writes an env var (declared in the kernelspec `env`) to a file,
+    # so we can assert the kernelspec environment actually reached the process.
+    out = tmp_path / "env_seen.txt"
+    script = f"import os; open({str(out)!r}, 'w').write(os.environ.get('FPS_ENV_TEST', 'MISSING'))"
+    kernelspec = tmp_path / "kernel.json"
+    kernelspec.write_text(
+        json.dumps(
+            {
+                "argv": ["python", "-c", script, "{connection_file}"],
+                "display_name": "env-test",
+                "language": "python",
+                "env": {"FPS_ENV_TEST": "from-kernelspec"},
+            }
+        )
+    )
+    # The value must come from the kernelspec, not be inherited from the parent.
+    monkeypatch.delenv("FPS_ENV_TEST", raising=False)
+
+    async with create_task_group() as tg:
+        kernel = KernelSubprocess(
+            write_connection_file=True,
+            kernelspec_path=str(kernelspec),
+            connection_file="",
+            kernel_cwd=str(tmp_path),
+            capture_output=False,
+        )
+        await tg.start(kernel.start)
+        try:
+            with fail_after(30):
+                while not out.exists():
+                    await sleep(0.05)
+        finally:
+            await kernel.stop()
+
+    assert out.read_text() == "from-kernelspec"

--- a/plugins/kernel_subprocess/tests/test_kernel_env.py
+++ b/plugins/kernel_subprocess/tests/test_kernel_env.py
@@ -8,10 +8,16 @@ pytestmark = pytest.mark.anyio
 
 
 async def test_kernelspec_env_is_passed_to_kernel(tmp_path, monkeypatch):
-    # The kernel writes an env var (declared in the kernelspec `env`) to a file,
-    # so we can assert the kernelspec environment actually reached the process.
+    # The kernel writes its env vars to a file so we can assert they reached the
+    # process and that references were expanded. POSIX path: backslashes from a
+    # Windows path would break the embedded string literal.
     out = tmp_path / "env_seen.txt"
-    script = f"import os; open('{out}', 'w').write(os.environ.get('FPS_ENV_TEST', 'MISSING'))"
+    script = (
+        "import os; "
+        f"open('{out.as_posix()}', 'w').write("
+        "os.environ.get('FPS_ENV_TEST', 'MISSING') + '|' + "
+        "os.environ.get('FPS_ENV_EXPANDED', 'MISSING'))"
+    )
     kernelspec = tmp_path / "kernel.json"
     kernelspec.write_text(
         json.dumps(
@@ -19,12 +25,17 @@ async def test_kernelspec_env_is_passed_to_kernel(tmp_path, monkeypatch):
                 "argv": ["python", "-c", script, "{connection_file}"],
                 "display_name": "env-test",
                 "language": "python",
-                "env": {"FPS_ENV_TEST": "from-kernelspec"},
+                "env": {
+                    "FPS_ENV_TEST": "from-kernelspec",
+                    "FPS_ENV_EXPANDED": "prefix:${FPS_ENV_BASE}",
+                },
             }
         )
     )
-    # The value must come from the kernelspec, not be inherited from the parent.
+    # FPS_ENV_TEST must come from the kernelspec, not be inherited from the parent.
     monkeypatch.delenv("FPS_ENV_TEST", raising=False)
+    # FPS_ENV_BASE is referenced by the kernelspec `env` and must be expanded.
+    monkeypatch.setenv("FPS_ENV_BASE", "base-value")
 
     async with create_task_group() as tg:
         kernel = KernelSubprocess(
@@ -42,4 +53,4 @@ async def test_kernelspec_env_is_passed_to_kernel(tmp_path, monkeypatch):
         finally:
             await kernel.stop()
 
-    assert out.read_text() == "from-kernelspec"
+    assert out.read_text() == "from-kernelspec|prefix:base-value"


### PR DESCRIPTION
fps_kernel_subprocess starts the kernel with open_process(...), but it does not pass the env variables from the kernelspec to the subprocess.
As a result, kernels that depend on these variables start with the wrong environment.
For example, xeus-r defines R_HOME and LD_LIBRARY_PATH in its kernel.json.
Without these variables, it fails to start and exits with: Fatal error: R home directory is not defined
